### PR TITLE
Fix crash when when stream list is empty

### DIFF
--- a/src/audio/music_player.rs
+++ b/src/audio/music_player.rs
@@ -271,6 +271,6 @@ impl MusicPlayer {
     }
 
     pub fn currently_playing(&self) -> Option<String> {
-        Some(self.streams[self.index].name.clone())
+        Some(self.streams.get(self.index)?.name.clone())
     }
 }


### PR DESCRIPTION
When no streams are present in assets/data/stream_data.json, the game crashes after launch due to out of bounds access.