### PR TITLE
Fixed the teleport button label to show no cost when the destination is player's home planet.

### DIFF
--- a/src/core/team.rs
+++ b/src/core/team.rs
@@ -342,11 +342,7 @@ impl Team {
             return Err(anyhow!("Cannot use teleportation pad on {}", to.name));
         }
 
-        let rum_required = if self.home_planet_id == to.id {
-            0
-        } else {
-            self.player_ids.len() as u32
-        };
+        let rum_required = self.teleport_rum_cost(to.id);
         let has_rum = self.resources.value(&Resource::RUM) >= rum_required;
 
         if !has_rum {
@@ -1033,5 +1029,12 @@ impl Team {
         new_players.append(&mut bench.iter().map(|&p| p.id).collect::<Vec<PlayerId>>());
 
         new_players
+    }
+
+    pub fn teleport_rum_cost(&self, planet_id: PlanetId) -> u32 {
+        match self.home_planet_id == planet_id {
+            true => 0,
+            false => self.player_ids.len() as u32,
+        }
     }
 }

--- a/src/core/team.rs
+++ b/src/core/team.rs
@@ -1032,9 +1032,10 @@ impl Team {
     }
 
     pub fn teleport_rum_cost(&self, planet_id: PlanetId) -> u32 {
-        match self.home_planet_id == planet_id {
-            true => 0,
-            false => self.player_ids.len() as u32,
+        if self.home_planet_id == planet_id {
+            0
+        } else {
+            self.player_ids.len() as u32
         }
     }
 }

--- a/src/ui/ui_callback.rs
+++ b/src/ui/ui_callback.rs
@@ -827,8 +827,8 @@ impl UiCallback {
 
             let is_teleporting = duration == TELEPORT_TRAVEL_DURATION;
             if is_teleporting {
-                if planet_id != own_team.home_planet_id {
-                    let rum_consumed = own_team.player_ids.len() as u32;
+                let rum_consumed = own_team.teleport_rum_cost(planet_id);
+                if rum_consumed > 0 {
                     own_team.sub_resource(Resource::RUM, rum_consumed)?;
                 }
             } else {

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -111,7 +111,7 @@ pub fn teleport_button<'a>(world: &World, planet_id: PlanetId) -> AppResult<Butt
     let planet = world.planets.get_or_err(&planet_id)?;
 
     let button_label = match own_team.home_planet_id == planet_id {
-        true => String::from("Teleport"),
+        true => "Teleport".to_string(),
         false => format!("Teleport (-{} Rum)", own_team.player_ids.len()),
     };
 

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -110,9 +110,10 @@ pub fn teleport_button<'a>(world: &World, planet_id: PlanetId) -> AppResult<Butt
     let own_team = world.get_own_team()?;
     let planet = world.planets.get_or_err(&planet_id)?;
 
-    let button_label = match own_team.home_planet_id == planet_id {
+    let rum_cost = own_team.teleport_rum_cost(planet_id);
+    let button_label = match rum_cost == 0 {
         true => "Teleport".to_string(),
-        false => format!("Teleport (-{} Rum)", own_team.player_ids.len()),
+        false => format!("Teleport (-{} Rum)", rum_cost),
     };
 
     let mut teleport_button = Button::new(
@@ -122,10 +123,10 @@ pub fn teleport_button<'a>(world: &World, planet_id: PlanetId) -> AppResult<Butt
     .set_hover_text(format!(
         "Travel instantaneously to {}{}",
         planet.name,
-        if planet_id == own_team.home_planet_id {
+        if rum_cost == 0 {
             String::new()
         } else {
-            format!(" for {} Rum", own_team.player_ids.len()) // FIXME: don't hardcode this, but get it somehow from the teleport action.)
+            format!(" for {} Rum", rum_cost)
         }
     ))
     .set_hotkey(ui_key::TRAVEL);

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -110,8 +110,13 @@ pub fn teleport_button<'a>(world: &World, planet_id: PlanetId) -> AppResult<Butt
     let own_team = world.get_own_team()?;
     let planet = world.planets.get_or_err(&planet_id)?;
 
+    let button_label = match own_team.home_planet_id == planet_id {
+        true => String::from("Teleport"),
+        false => format!("Teleport (-{} Rum)", own_team.player_ids.len()),
+    };
+
     let mut teleport_button = Button::new(
-        format!("Teleport (-{} Rum)", own_team.player_ids.len()),
+        button_label,
         UiCallback::TravelToPlanet { planet_id },
     )
     .set_hover_text(format!(

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -111,9 +111,10 @@ pub fn teleport_button<'a>(world: &World, planet_id: PlanetId) -> AppResult<Butt
     let planet = world.planets.get_or_err(&planet_id)?;
 
     let rum_cost = own_team.teleport_rum_cost(planet_id);
-    let button_label = match rum_cost == 0 {
-        true => "Teleport".to_string(),
-        false => format!("Teleport (-{} Rum)", rum_cost),
+    let button_label = if rum_cost > 0 {
+        format!("Teleport (-{} Rum)", rum_cost)
+    } else {
+        "Teleport".to_string()
     };
 
     let mut teleport_button = Button::new(


### PR DESCRIPTION
In the Galaxy tab, when a teleport action is available, a check is added to see if the destination planet is matching the player's home planet. If that's the case, no cost is displayed.